### PR TITLE
Update plugin version for Jenkins v2.289.2

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -1,6 +1,5 @@
-blueocean:1.23.2
-email-ext:2.75
-envinject:2.3.0
-groovy:2.2
-ldap:1.25
+email-ext:2.82
+envinject:2.4.0
+groovy:2.3
+ldap:2.7
 job-dsl:1.77


### PR DESCRIPTION
Update plugin version for Jenkins v2.289.2. And install latest version of _Matrix Authorization Strategy_ plugin.